### PR TITLE
bugfix: add python-dotenv to requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 requests>=2.32
 psycopg[binary]>=3.0
+python-dotenv>=1.2.1

--- a/src/intraday_data_collection.py
+++ b/src/intraday_data_collection.py
@@ -9,18 +9,21 @@ import os
 import datetime as dt
 import sys
 import requests
+from dotenv import load_dotenv
 from zoneinfo import ZoneInfo
 
 # DB client
 import psycopg
 
 # Internal utilities
-from src import data_validation as dv
-from src import time_utils as tu
-from src import db_utils as dbu
-from src import logging_utils as lu
+import data_validation as dv
+import time_utils as tu
+import db_utils as dbu
+import logging_utils as lu
+
 
 # load in environment vars 
+load_dotenv()
 API_KEY        = os.environ.get("FMP_API_KEY", "")
 SYMBOLS        = os.environ.get("SYMBOLS", "AAPL").split(",")
 MARKET_TZ      = os.environ.get("MARKET_TZ", "America/New_York")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -201,7 +201,11 @@ def mock_execute_values(monkeypatch):
 def mock_error_log_dir(tmp_path, monkeypatch):
     """Mock ERROR_LOG_DIR to use temp directory instead of /usr/local/dc_error_logs."""
     from src import logging_utils
+    from src import intraday_data_collection
     
     error_log_dir = tmp_path / "dc_error_logs"
+    # Patch the module directly
     monkeypatch.setattr(logging_utils, "ERROR_LOG_DIR", error_log_dir)
+    # Also patch the reference in intraday_data_collection.lu
+    monkeypatch.setattr(intraday_data_collection.lu, "ERROR_LOG_DIR", error_log_dir)
     return error_log_dir

--- a/tests/pipeline/test_main_execution.py
+++ b/tests/pipeline/test_main_execution.py
@@ -83,7 +83,7 @@ def test_main_exits_when_db_connection_fails(mock_env_complete, monkeypatch, cap
     def mock_db_connect_fail(host, port, dbname, user, password):
         raise Exception("Connection refused")
     
-    monkeypatch.setattr(dbu, "db_connect", mock_db_connect_fail)
+    monkeypatch.setattr(collector.dbu, "db_connect", mock_db_connect_fail)
     
     # When: Running main() and expecting system exit (¬Q)
     with pytest.raises(SystemExit) as exc_info:
@@ -105,7 +105,7 @@ def test_main_successful_execution(mock_env_complete, mock_successful_api, monke
     def mock_db_connect(host, port, dbname, user, password):
         return mock_conn
     
-    monkeypatch.setattr(dbu, "db_connect", mock_db_connect)
+    monkeypatch.setattr(collector.dbu, "db_connect", mock_db_connect)
     
     # When: Running main()
     collector.main()
@@ -138,7 +138,7 @@ def test_main_continues_after_symbol_error(mock_env_complete, monkeypatch, capsy
             raise Exception("API rate limit exceeded")
         return 5  # Successful for other symbols
     
-    monkeypatch.setattr(dbu, "db_connect", mock_db_connect)
+    monkeypatch.setattr(collector.dbu, "db_connect", mock_db_connect)
     monkeypatch.setattr(collector, "fetch_and_insert", mock_fetch_and_insert)
     
     # When: Running main()
@@ -181,7 +181,7 @@ def test_main_loads_env_vars_at_runtime(monkeypatch, capsys, mock_error_log_dir)
     def mock_fetch_and_insert(conn, symbol, start, end):
         return 0
     
-    monkeypatch.setattr(dbu, "db_connect", mock_db_connect)
+    monkeypatch.setattr(collector.dbu, "db_connect", mock_db_connect)
     monkeypatch.setattr(collector, "fetch_and_insert", mock_fetch_and_insert)
     
     # When: Running main()
@@ -207,7 +207,7 @@ def test_main_computes_time_window(mock_env_complete, monkeypatch, capsys, mock_
         captured_window["end"] = end
         return 0
     
-    monkeypatch.setattr(dbu, "db_connect", mock_db_connect)
+    monkeypatch.setattr(collector.dbu, "db_connect", mock_db_connect)
     monkeypatch.setattr(collector, "fetch_and_insert", mock_fetch_and_insert)
     
     # When: Running main()


### PR DESCRIPTION
## Description
This change adds python-dotenv to the requirements to allow environment variables to be kept secret.

## Changes
- Added python-dotenv to requirements.txt
- changed import syntax

## Why
The script was not running properly without setting the environment variables manually from the command line.

## Type of Change
- [ ] feat: New feature
- [x] fix: Bug fix
- [ ] test: Test additions or improvements
- [ ] docs: Documentation updates
- [ ] chore: Tooling, dependencies, or CI/CD changes
- [ ] refactor: Code restructuring (no behavior change)

## Testing
How was this tested? What scenarios were verified?

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing (describe)

>ran the intraday_data_collection.py script from the command line. Checked the database for new records.

## Breaking Changes
Does this break existing functionality or the public API?

- [x] No breaking changes
- [ ] Yes, breaking changes (describe below)

## Related Issues
N/A

## Checklist
- [x] Code follows project style guidelines
- [ ] Self-review completed
- [x] Comments added for complex logic
- [ ] Documentation updated (if needed)
- [x] No new warnings generated
- [ ] Tests pass locally
