### PR TITLE
Fix/mismatch column names sql script

### DIFF
--- a/src/run_scheduled_operations.py
+++ b/src/run_scheduled_operations.py
@@ -182,7 +182,7 @@ def execute_sql_script(
             logger.error(f"   Duration: {duration:.2f}s")
         
         # Log failure to pipeline_logs
-        log_execution(conn, script_name, 'failure', duration, error_msg)
+        log_execution(conn, script_name, 'failed', duration, error_msg)
         
         return False, error_msg
 

--- a/src/sql_operations/export_stg_to_core.sql
+++ b/src/sql_operations/export_stg_to_core.sql
@@ -133,17 +133,14 @@ core_insert AS (
 watermark_update AS (
     INSERT INTO operation_logs.pipeline_watermarks (
         pipeline_name,
-        last_processed_ts,
-        record_count
+        last_processed_ts
     )
     SELECT
         'export_stg_to_core',
-        MAX(ts),
-        COUNT(*)
+        MAX(ts)
     FROM valid
     ON CONFLICT (pipeline_name) DO UPDATE SET
-        last_processed_ts = EXCLUDED.last_processed_ts,
-        record_count = EXCLUDED.record_count
+        last_processed_ts = EXCLUDED.last_processed_ts
 )
 
 SELECT 'export_stg_to_core execution complete';

--- a/src/sql_operations/export_stg_to_core.sql
+++ b/src/sql_operations/export_stg_to_core.sql
@@ -76,15 +76,13 @@ log_quality_errors AS (
         symbol,
         ts,
         error_type,
-        error_detail,
-        severity
+        error_detail
     )
     SELECT
         symbol,
         ts,
         quality_issue,
-        to_jsonb(quality_checks),
-        'high'
+        to_jsonb(quality_checks)
     FROM quality_checks
     WHERE quality_issue IS NOT NULL
 ),

--- a/src/sql_operations/export_stg_to_core.sql
+++ b/src/sql_operations/export_stg_to_core.sql
@@ -15,7 +15,6 @@ WITH ranked AS (
         volume,
         asset_type,
         source,
-        raw_payload,
         ingest_time,
         ROW_NUMBER() OVER (
             PARTITION BY symbol, ts
@@ -99,7 +98,7 @@ valid AS (
 --------------------------------------------------
 
 core_insert AS (
-    INSERT INTO core_dbms.market_data (
+    INSERT INTO core_dbms.market_data_5m (
         symbol,
         ts,
         open,
@@ -108,9 +107,7 @@ core_insert AS (
         close,
         volume,
         asset_type,
-        source,
-        raw_payload,
-        ingest_time
+        source
     )
     SELECT
         symbol,
@@ -119,19 +116,16 @@ core_insert AS (
         high,
         low,
         close,
-        volume,
+        volume::BIGINT,
         asset_type,
-        source,
-        raw_payload,
-        ingest_time
+        source
     FROM valid
     ON CONFLICT (symbol, ts) DO UPDATE SET
         open = EXCLUDED.open,
         high = EXCLUDED.high,
         low = EXCLUDED.low,
         close = EXCLUDED.close,
-        volume = EXCLUDED.volume,
-        ingest_time = EXCLUDED.ingest_time
+        volume = EXCLUDED.volume
 ),
 
 --------------------------------------------------

--- a/tests/unit/test_run_scheduled_operations.py
+++ b/tests/unit/test_run_scheduled_operations.py
@@ -162,7 +162,7 @@ class TestExecuteSqlScript:
         
         # Verify log call has failure status
         log_call_args = mock_log.call_args
-        assert log_call_args[0][2] == 'failure'  # status argument
+        assert log_call_args[0][2] == 'failed'  # status argument
     
     @pytest.mark.unit
     @patch('run_scheduled_operations.read_sql_file')


### PR DESCRIPTION
## Description
Fix the mismatch between function calls and the actual DB column names

## Changes
- Modified the stg to core script to properly target the column names correctly.

## Why
Data was not getting to the core table because the script was using the wrong column names.

## Type of Change
- [x] fix: Bug fix

## Testing
How was this tested? What scenarios were verified?

- [x] Manual testing (Logged into cosc-admin and ran the script manually and dubugged until it stopped outputting errors)

## Breaking Changes
Does this break existing functionality or the public API?

- [x] No breaking changes

If yes, describe the breaking changes:

## Related Issues
Closes #67 

## Checklist
- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Comments added for complex logic
- [x] Documentation updated (if needed)
- [x] No new warnings generated
- [x] Tests pass locally
