### PR TITLE
Load environment variables in scheduled operations setup script

### DIFF
--- a/setup_scripts/setup_cronjob_scheduled_operations.sh
+++ b/setup_scripts/setup_cronjob_scheduled_operations.sh
@@ -73,6 +73,8 @@ TEMP_CHECK=$(mktemp)
 if ! sudo -u "$RUN_AS_USER" "$PYTHON" -c "
 import psycopg
 import os
+from dotenv import load_dotenv
+load_dotenv('$ENVFILE')
 try:
     conn = psycopg.connect(
         host=os.getenv('PGHOST', 'localhost'),


### PR DESCRIPTION
## Description
This pull request makes a minor improvement to the `setup_cronjob_scheduled_operations.sh` script by ensuring environment variables from the `.env` file are loaded before establishing a database connection.

## Changes
- Added `dotenv` support to load environment variables from the specified `.env` file before attempting to connect to the database in the Python snippet.

## Why
Database schema verification was failing on the scheduled operations setup script. It was returning a warning regarding a schema not existing in the database even though it was there.

## Type of Change
- [ ] feat: New feature
- [x] fix: Bug fix
- [ ] test: Test additions or improvements
- [ ] docs: Documentation updates
- [ ] chore: Tooling, dependencies, or CI/CD changes
- [ ] refactor: Code restructuring (no behavior change)

## Testing
How was this tested? What scenarios were verified?

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing (describe)
I ran the updated script manually and it didn't return a warning anymore.

## Breaking Changes
Does this break existing functionality or the public API?

- [x] No breaking changes
- [ ] Yes, breaking changes (describe below)

If yes, describe the breaking changes:

## Related Issues
None

## Checklist
- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Comments added for complex logic
- [x] Documentation updated (if needed)
- [x] No new warnings generated
- [x] Tests pass locally
